### PR TITLE
Add method to enable remapping of BPMN ids

### DIFF
--- a/src/main/java/de/jena/uni/mojo/error/DeadlockAnnotation.java
+++ b/src/main/java/de/jena/uni/mojo/error/DeadlockAnnotation.java
@@ -215,4 +215,16 @@ public class DeadlockAnnotation extends Annotation {
 		return extractOriginalNodes(failureNodes);
 	}
 
+	public List<List<AbstractEdge>> getListOfFailurePaths() {
+		List<List<AbstractEdge>> listOfPaths = new ArrayList<>();
+		for (BitSet path : this.pathsToFailure) {
+			// Extract the workflow graph edges
+			List<Edge> wfgEdges = this.extractEdgePath(path);
+
+			listOfPaths.add(extractAbstractPath(wfgEdges));
+		}
+
+		return listOfPaths;
+	}
+
 }


### PR DESCRIPTION
adds a simple method to be used by BPMNspector to map WFGraph edges to the BPMN element ids